### PR TITLE
fix regex to handle usernames with '-' for squashfs

### DIFF
--- a/pkg/squashfsparser/squashfsparser.go
+++ b/pkg/squashfsparser/squashfsparser.go
@@ -37,7 +37,7 @@ const (
 
 var (
 	// drwxr-xr-x administrator/administrator 66 2019-04-08 18:49 squashfs-root
-	fileLineRegex = regexp.MustCompile(`^([A-Za-z-]+)\s+(\w+|\d+)/(\w+|\d+)\s+(\d+)\s+(\d+-\d+-\d+)\s+(\d+:\d+)\s+(.*)$`)
+	fileLineRegex = regexp.MustCompile(`^([A-Za-z-]+)\s+([-\w]+|\d+)/([-\w]+|\d+)\s+(\d+)\s+(\d+-\d+-\d+)\s+(\d+:\d+)\s+(.*)$`)
 )
 
 // SquashFSParser parses SquashFS filesystem images.


### PR DESCRIPTION
unsquashfs converts UID/GID to usernames found on the system it is running on, if the username or group contains '-' the parser broke

this PR allows '-'

do we need other characters too?