### PR TITLE
fix filecontent script file/dir iterate

### DIFF
--- a/pkg/analyzer/filecontent/filecontent.go
+++ b/pkg/analyzer/filecontent/filecontent.go
@@ -274,8 +274,8 @@ type callbackDataType struct {
 func checkFileScript(fi *fsparser.FileInfo, fullpath string, cbData analyzer.AllFilesCallbackData) {
 	cbd := cbData.(*callbackDataType)
 
-	// skip/ignore links
-	if fi.IsLink() {
+	// skip/ignore anything but normal files
+	if !fi.IsFile() {
 		return
 	}
 

--- a/pkg/analyzer/filecontent/filecontent_test.go
+++ b/pkg/analyzer/filecontent/filecontent_test.go
@@ -64,7 +64,7 @@ func makeFile(data string, fn string) fsparser.FileInfo {
 	if err != nil {
 		panic(err)
 	}
-	return fsparser.FileInfo{Name: fn, Size: 1}
+	return fsparser.FileInfo{Name: fn, Size: 1, Mode: 100666}
 }
 
 func TestRegex(t *testing.T) {


### PR DESCRIPTION
- only copy out files (e2cp creates a dummy file if a directory is non recursively copied - cp fails)