### PR TITLE
add quiet flag as sometimes block count ends up in the middle of the …

### DIFF
--- a/pkg/cpioparser/cpioparser.go
+++ b/pkg/cpioparser/cpioparser.go
@@ -200,7 +200,7 @@ func (p *CpioParser) loadFileList() error {
 	}
 	p.files = make(map[string][]fsparser.FileInfo)
 
-	out, err := exec.Command("sh", "-c", cpioCmd+" -tvn < "+p.imagepath).CombinedOutput()
+	out, err := exec.Command("sh", "-c", cpioCmd+" -tvn --quiet < "+p.imagepath).CombinedOutput()
 	if err != nil {
 		if err.Error() != errors.New("exit status 2").Error() {
 			fmt.Fprintf(os.Stderr, "getDirList: >%s<", err)


### PR DESCRIPTION
bug fix 
- add quiet flag as sometimes block count ends up in the middle of the output (if output is large)