### PR TITLE
added cpiofs fixdir option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### Fixed
 - _check.py_ fix to support pathnames with spaces
 - _cpiofs_ fix date parsing
+- _cpiofs_ added work around for missing directory entries
 
 ## [v1.3.1] - 2020-01-07
 

--- a/Readme.md
+++ b/Readme.md
@@ -100,9 +100,11 @@ The `FsType` (filesystem type) field selects the backend that is used to access 
 - `squashfs`: to read SquashFS filesystem images (supported FsTypeOptions are: N/A)
 - `ubifs`: to read UBIFS filesystem images (supported FsTypeOptions are: N/A)
 - `vfatfs`: to read VFat filesystem images (supported FsTypeOptions are: N/A)
-- `cpiofs`: to read cpio archives (supported FsTypeOptions are: N/A)
+- `cpiofs`: to read cpio archives (supported FsTypeOptions are: `fixdirs`)
 
 The FsTypeOptions allow tuning of the FsType driver.
+- `selinux`: will enable selinux support when reading ext filesystem images
+- `fixdirs`: will attempt to work around a cpio issue where a file exists in a directory while there is no entry for the directory itself
 
 The `DigestImage` option will generate a SHA-256 digest of the filesystem image that was analyzed, the digest will be included in the output.
 

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -127,7 +127,7 @@ func NewFromConfig(imagepath string, cfgdata string) *Analyzer {
 	} else if strings.EqualFold(config.GlobalConfig.FSType, "ubifs") {
 		fsp = ubifsparser.New(imagepath)
 	} else if strings.EqualFold(config.GlobalConfig.FSType, "cpiofs") {
-		fsp = cpioparser.New(imagepath)
+		fsp = cpioparser.New(imagepath, config.GlobalConfig.FSTypeOptions == "fixdirs")
 	} else {
 		panic("Cannot find an appropriate parser: " + config.GlobalConfig.FSType)
 	}

--- a/pkg/cpioparser/cpioparser_test.go
+++ b/pkg/cpioparser/cpioparser_test.go
@@ -32,7 +32,7 @@ type testData struct {
 
 func TestParseLine(t *testing.T) {
 	testImage := "../../test/test.cpio"
-	p := New(testImage)
+	p := New(testImage, true)
 
 	testdata := []testData{
 		{`-rw-r--r--   1 0        0              21 Apr 11  2008 etc/motd`, 0100644, "/etc/", "motd", true, ""},
@@ -61,9 +61,43 @@ func TestParseLine(t *testing.T) {
 	}
 }
 
+func TestFixDir(t *testing.T) {
+	testImage := "../../test/test.cpio"
+	p := New(testImage, true)
+
+	testdata := `
+crw-r--r--   1 0        0          3,   1 Jan 13 17:57 dev/ttyp1
+crw-r--r--   1 0        0          3,   1 Jan 13 17:57 dev/x/ttyp1`
+
+	err := p.loadFileListFromString(testdata)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ok := false
+	for _, fn := range p.files["/"] {
+		if fn.Name == "dev" {
+			ok = true
+		}
+	}
+	if !ok {
+		t.Errorf("dir '/dev' not found")
+	}
+
+	ok = false
+	for _, fn := range p.files["/dev"] {
+		if fn.Name == "x" {
+			ok = true
+		}
+	}
+	if !ok {
+		t.Errorf("dir '/dev/x' not found")
+	}
+}
+
 func TestFull(t *testing.T) {
 	testImage := "../../test/test.cpio"
-	p := New(testImage)
+	p := New(testImage, false)
 
 	fi, err := p.GetFileInfo("/")
 	if err != nil {


### PR DESCRIPTION
added fixdir option for cpiofs 

  With cpio it is possible that a file exists in a directory that does not have its own entry.
   e.g. "dev/tty6" exists in the cpio but there is no entry for "dev"
  This function creates the missing directories in the internal structure.
 