### PR TITLE
check.py: Avoid shell=True in subprocess calls

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- _check.py_ cleaned up a bit, avoiding using `shell=True` in subprocess invocations.
+
 ## [v1.3.2] - 2020-01-15
 
 ### Fixed


### PR DESCRIPTION
This simply breaks up the args into a list of args so we can avoid using shell=True